### PR TITLE
target multiple frameworks

### DIFF
--- a/VtNetCore.Unit.Tests/VtNetCoreUnitTests.csproj
+++ b/VtNetCore.Unit.Tests/VtNetCoreUnitTests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.0;net45;net46</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/VtNetCore/VtNetCore.csproj
+++ b/VtNetCore/VtNetCore.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Darren R. Starr</Authors>
     <Company>Telenor Inpli AS</Company>
@@ -14,4 +14,8 @@
     <PackageLicenseUrl>https://github.com/darrenstarr/VtNetCore/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>VT-100 VT220 xterm NetCore</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
.NET Standard 2.0 is only supported by .NET 4.7.1 and newer, but older frameworks than that have the required features for VTNetCore to compile. This PR targets multiple frameworks to enable the consumption of this library on older versions of .NET. This is especially useful for people who may want to use this library on Windows 7 which doesn't come with .NET 4.7.1 by default.