### PR TITLE
Fixes a bug in OSC-112 control sequences 

### DIFF
--- a/VtNetCore.Unit.Tests/OCSBug.cs
+++ b/VtNetCore.Unit.Tests/OCSBug.cs
@@ -1,0 +1,95 @@
+using Xunit;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+using ConnectionNode;
+using VtNetCore.VirtualTerminal;
+using VtNetCore.XTermParser;
+
+namespace ConnectionNode.Tests.UnitTests
+{
+
+public class OCSBug
+{
+
+    // Created this so we can expect the input buffer and ensure the bug is fixed
+    public class TransparentDataConsumer : DataConsumer
+    {
+        public TransparentDataConsumer(IVirtualTerminalController controller) : base(controller) {}
+        public XTermInputBuffer GetInputBuffer() 
+        { return this.InputBuffer; }
+    }
+
+    private void Push(DataConsumer d, string s)
+    {
+        d.Push(Encoding.UTF8.GetBytes(s));
+    }
+
+    [Fact]
+    public void OSC112BugTest()
+    {
+        var TerminalController = new VirtualTerminalController();
+        var d = new TransparentDataConsumer(TerminalController);
+
+        int count = 250;
+        
+        Stopwatch timeBefore = new Stopwatch();
+        timeBefore.Start();
+        for (int i=0; i< count; i++) {
+            Push(d, "TheQuickBrownFoxjumpedOverTheLazyDog.");
+        }
+        timeBefore.Stop();
+
+        Assert.Equal(0, d.GetInputBuffer().Remaining);
+        Assert.Equal(0, d.GetInputBuffer().Position);
+        Assert.Equal(0, d.GetInputBuffer().Buffer.Length);
+
+        // OSC-112
+        // ESC-]-112-BELL
+        Push(d, "\u001b]112\u0007");
+
+        Assert.Equal(0, d.GetInputBuffer().Remaining);
+        Assert.Equal(0, d.GetInputBuffer().Position);
+        Assert.Equal(0, d.GetInputBuffer().Buffer.Length);
+
+        Stopwatch timeAfter = new Stopwatch();
+        timeAfter.Start();
+        for (int i=0; i< count; i++) {
+            Push(d, "TheQuickBrownFoxjumpedOverTheLazyDog.");
+        }
+        timeAfter.Stop();
+
+        // Assert that same operations don't take ten times as long, the second time you do them.
+        Assert.True((timeBefore.ElapsedMilliseconds*10) > timeAfter.ElapsedMilliseconds);
+
+        Assert.Equal(0, d.GetInputBuffer().Remaining);
+        Assert.Equal(0, d.GetInputBuffer().Position);
+        Assert.Equal(0, d.GetInputBuffer().Buffer.Length);
+    }
+   
+    [Fact]
+    public void TmuxStartingUpTest()
+    {   
+
+        // This bug was originally triggered by tmux. We use a recorded tmux as a test case here to ensure the bug doesn't reoccur.
+        List<String> tmuxsession = new List<String>{"dA==", "bQ==", "dQ==", "eA==", "DQo=", "G1s/MTA0OWgbKEIbW20bWz8xbBs+G1tIG1syShtbPzEybBtbPzI1aBtbPzEwMDBsG1s/MTAwNmwbWz8xMDA1bBtbYxtbPjQ7MW0bWz8xMDA0aBtdMTEyBxtbPzI1bBtbMTsxSBtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobW0sNChtbSw0KG1tLDQobWzMwbRtbNDJtWzBdIDA6YmFzaCogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICJpcC0xNzItMzEtODEtODcuZWMyLmluIiAyMjowNSAwNS1PY3QtMjIbKEIbW20bWzYwOzFIG1sxOzYwchtbSBtbPzEybBtbPzI1aA==", "G1s/MjVsG1s2MGQbWzMwbRtbNDJtWzBdIDA6c3NtLXVzZXJAaXAtMTcyLTMxLTgxLTg3On4qICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICJpcC0xNzItMzEtODEtODcuZWMyLmluIiAyMjowNSAwNS1PY3QtMjIbKEIbW20bWzE7MUgbWz8xMmwbWz8yNWg=", "G1sxOzU5cltzc20tdXNlckBpcC0xNzItMzEtODEtODcgfl0kIBtbMTs2MHIbW0gbWzMwQw==", "G1sxOzU5chtbSBtbMzBDdBtbMTs2MHIbW0gbWzMxQw==", "G1sxOzU5chtbSBtbMzFDbxtbMTs2MHIbW0gbWzMyQw==", "G1sxOzU5chtbSBtbMzJDcBtbMTs2MHIbW0gbWzMzQw==", "DQo=", "G1s/MjVsG1s/MWgbPQ==", "G1sxOzU5chtbSBtbSw0KG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1sxQhtbSxtbMUIbW0sbWzFCG1tLG1tIdG9wIC0gMjI6MDU6NTQgdXAgMzIgbWluLCAgMCB1c2VycywgIGxvYWQgYXZlcmFnZTogMC4wMCwgMC4wMCwgMC4wMBtbSw0KVGFza3M6G1sxbSAxMDIgGyhCG1ttdG90YWwsG1sxbSAgIDEgGyhCG1ttcnVubmluZywbWzFtICA2NCAbKEIbW21zbGVlcGluZywbWzFtICAgMCAbKEIbW21zdG9wcGVkLBtbMW0gICAwIBsoQhtbbXpvbWJpZRtbSw0KJUNwdShzKTobWzFtICAwLjAgGyhCG1ttdXMsG1sxbSAgMC4wIBsoQhtbbXN5LBtbMW0gIDAuMCAbKEIbW21uaSwbWzFtMTAwLjAgGyhCG1ttaWQsG1sxbSAgMC4wIBsoQhtbbXdhLBtbMW0gIDAuMCAbKEIbW21oaSwbWzFtICAwLjAgGyhCG1ttc2ksG1sxbSAgMC4wIBsoQhtbbXN0G1tLDQpLaUIgTWVtIDobWzFtICAxMDA1ODI0IBsoQhtbbXRvdGFsLBtbMW0gICAzODY5NDggGyhCG1ttZnJlZSwbWzFtICAgMTMzMzA4IBsoQhtbbXVzZWQsG1sxbSAgIDQ4NTU2OCAbKEIbW21idWZmL2NhY2hlG1tLDQpLaUIgU3dhcDobWzFtICAgICAgICAwIBsoQhtbbXRvdGFsLBtbMW0gICAgICAgIDAgGyhCG1ttZnJlZSwbWzFtICAgICAgICAwIBsoQhtbbXVzZWQuG1sxbSAgIDcxNDg5MiAbKEIbW21hdmFpbCBNZW0gG1tLDQobW0sNCg=="};
+
+        var TerminalController = new VirtualTerminalController();
+        var d = new TransparentDataConsumer(TerminalController);
+
+        foreach (String consoleOut in tmuxsession){
+            byte[] data = Convert.FromBase64String(consoleOut);
+            d.Push(data);
+        }
+
+        Assert.Equal(0, d.GetInputBuffer().Remaining);
+        Assert.Equal(0, d.GetInputBuffer().Position);
+        Assert.Equal(0, d.GetInputBuffer().Buffer.Length);
+    }
+}
+
+}

--- a/VtNetCore/XTermParser/DataConsumer.cs
+++ b/VtNetCore/XTermParser/DataConsumer.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// The buffer to hold state for processing and parsing of incoming data
         /// </summary>
-        private XTermInputBuffer InputBuffer { get; set; } = new XTermInputBuffer();
+        protected XTermInputBuffer InputBuffer { get; set; } = new XTermInputBuffer();
 
         /// <summary>
         /// State information for when continuing to process data from a previously starved buffer condition

--- a/VtNetCore/XTermParser/XTermSequenceReader.cs
+++ b/VtNetCore/XTermParser/XTermSequenceReader.cs
@@ -130,10 +130,14 @@
             {
                 var next = stream.Read();
 
-                if (readingCommand)
+                if (readingCommand || next == 0x07 || next == 0x9C) // BEL or ST
                 {
-                    if (next == 0x07 || next == 0x9C)        // BEL or ST
+                    if (next == 0x07 || next == 0x9C) // BEL or ST
                     {
+                        if (currentParameter!=-1)
+                        {
+                            Parameters.Add(currentParameter);
+                        }
                         var osc = new OscSequence
                         {
                             Parameters = Parameters,


### PR DESCRIPTION
VTNetCore fail to make progress and begins taking longer and longer to process terminal output when supplied with the OSC-112 "reset text cursor color" control sequence `ESC ]112 BELL` ("\u001b]112\u0007"). Tmux uses this control sequence when it start up and will trigger this bug. Eventually it will use all memory and CPU resources that it can access and become wedged.

In this PR we provide:
* A unittest that replicate this bug from raw tmux terminal sessions,
* A unittest that replicates this bug from first principles
* and code which fix the OSC-112 bug.

Background on OSC (Operation System Sequences) 112
====

OSC terminal sequences [are documented in xterm](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) as having the following format:
```
OSC Ps ; Pt BEL
Ps   A single (usually optional) numeric parameter, composed of one or more digits.
Pt   A text parameter composed of printable characters.
If no parameters are given, this control has no effect.
```
Where OSC is the escape sequence, `ESC ]` (`\u001b]`),  for OSC control terminals.

[ECMA-48](https://www.ecma-international.org/publications-and-standards/standards/ecma-48/) provides the following description of OSC.
```
OSC - OPERATING SYSTEM COMMAND
Notation: (C1)
Representation: 09/13 or ESC 05/13
OSC is used as the opening delimiter of a control string for operating system use. The command string
following may consist of a sequence of bit combinations in the range 00/08 to 00/13 and 02/00 to 07/14.
The control string is closed by the terminating delimiter STRING TERMINATOR (ST). The
interpretation of the command string depends on the relevant operating system. 
```

[OSC 112 - reset cursor color](https://terminalguide.namepad.de/seq/osc-112/): resets the color of the text cursor. Since OSC-112 does that have a Pt (text parameter) and thus can is specified as either:

* `ESC ]112 BELL` (`\u001b]112\u0007`)
or 
* `ESC ]112; BELL` (`\u001b]112;\u0007`)

Tmux uses the version without the `;`. For instance here is the line of code where tmux defines OSC-112

```c
/* Terminal supports cursor colours. */
static const char *const tty_feature_ccolour_capabilities[] = {
 	"Cs=\\E]12;%p1%s\\a",
 	"Cr=\\E]112\\a",
 	NULL
};
```
[tmux/tty-features.c](https://github.com/tmux/tmux/blob/9c34aad21c0837123a51a5a4233a016805d3e526/tty-features.c#L206)

The Bug
====

The [OSC parser (ConsumeOSC) in VtNetCore](https://github.com/darrenstarr/VtNetCore/blob/060a72f074aafb8f8720f41616727a69755dade7/VtNetCore/XTermParser/XTermSequenceReader.cs#L114) assumes that [OSC control sequences](https://chromium.googlesource.com/apps/libapps/+/nassh-0.8.41/hterm/doc/ControlSequences.md#OSC) always fit the pattern:

`0x1b` + `]` + `<numeric parameters>` + `<command>` + `0x07`

This assumption is incorrect as the OSC-112 control sequence does not always have a letter after the numeric parameter 112. This means that VtNetCore's virtual terminal misses the BELL `0x07` character that should end the control sequence and assumes that all following text is actually part of the control sequence. Since the `0x07` character is very uncommon, it will reread all input it has seen on each new value sent to the data consumer waiting for the control sequence to complete. 

Lets step through what happens when the virtual terminal attempts to process `[\u00b1, ], 1, 1, 2, \u0007, A, B, C]`

1. The InputBuffer is empty, contains 0 elements, position is 0, remainder is 0.
2. `\u00b1]112\u0007ABC` is pushed to VtNetCore's DataConsumer i.e., `DataConsumer.Push("\u00b1]112\u0007ABC")`. Push adds this to the InputBuffer.
3. The InputBuffer is `[\u00b1, ], 1, 1, 2, \u0007, A, B, C]`, contains 8 elements, position is 0, remainder is 8
4. VtNetCore reads `\u00b1` and determines it is entering an escape sequence,
5. VtNetCore reads `]` and determines the escape sequence is an OSC sequence and uses ConsumeOSC to parse the OSC sequence
6. ConsumeOSC reads `1`, `1`, `2` as numeric parameters,
7. ConsumeOSC reads the bell character `\u0007` and sets `readingCommand = true;`
8. ConsumeOSC reads `A` assuming it is part of the command,
9. ConsumeOSC reads `B` assuming it is part of the command,
10. ConsumeOSC reads `A` assuming it is part of the command,
11. When it runs to the end of the InputBuffer it throws IndexOutOfRangeException,
12. This Exception is handled in the [DataConsumer L:102](https://github.com/darrenstarr/VtNetCore/blob/060a72f074aafb8f8720f41616727a69755dade7/VtNetCore/XTermParser/DataConsumer.cs#L102)
13. The InputBuffer is `[\u00b1, ], 1, 1, 2, \u0007, A, B, C]`, contains 8 elements, position is 8, remainder is 0
14. The code handling the IndexOutOfRangeException in DataConsumer calls `InputBuffer.PopAllStates()`,
15. The InputBuffer is `[\u00b1, ], 1, 1, 2, \u0007, A, B, C]`, contains 8 elements, position is 0, remainder is 8
16. DataConsumer.Push("\u00b1]112\u0007ABC")` returns
17. The user then calls DataConsumer.Push("DEFG")`
18. Push adds this to the InputBuffer. The InputBuffer is `[\u00b1, ], 1, 1, 2, \u0007, A, B, C, D, E, F, G]`, contains 12 elements, position is 0, remainder is 12,
19. The previous steps repeat with ConsumeOSC now believing `ABCDEFG` is the beginning of the OSC command,
20 As before when it runs to the end of the InputBuffer it throws IndexOutOfRangeException and resets the position,
20. The InputBuffer is `[\u00b1, ], 1, 1, 2, \u0007, A, B, C, D, E, F, G]`, contains 12 elements, position is 0, remainder is 12,
21. This continues with VtNetCore scanning over the ever growing input buffer on every `Push` but never making any progress.

By way of example this code can take a minute to finish:

```csharp
private void Push(DataConsumer d, string s)
{
    d.Push(Encoding.UTF8.GetBytes(s));
}

var TerminalController = new VirtualTerminalController();
var d = new DataConsumer(TerminalController);

int count = 3000;

// OSC-112
// ESC-]-112-BELL
Push(d, "\u001b]112\u0007");

Assert.Equal(0, d.GetInputBuffer().Remaining);
Assert.Equal(0, d.GetInputBuffer().Position);
Assert.Equal(0, d.GetInputBuffer().Buffer.Length);

Stopwatch timer = new Stopwatch();
timer.Start();
for (int i=0; i< count; i++) {
    Push(d, "TheQuickBrownFoxjumpedOverTheLazyDog.");
}
timer.Stop();

Console.WriteLine("Time: " +timer.ElapsedMilliseconds)
```

Why should anyone care about this bug?
====

Tmux will generate this control sequence on starting and thus bring down any VtNetCore virtual terminal that is reading tmux output. For instance in one tmux session I recorded the InputBuffer was 60KB and was being completely reread on each new DataConsumer.Push. This would take 7 seconds for each DataConsumer.Push to complete and the virtual terminal would never make progress on the InputBuffer.

The Fix
====

This fix allows the virtual terminal to recover from this control sequence by recognizing that a BEEP `0x07` character has been encountered even if no command has been submitted. This fix does not handle OSC-112, rather it just allows the virtual terminal to recover from it.